### PR TITLE
adding multiprocess option from python native multiprocess module

### DIFF
--- a/src/cnmf/cnmf.py
+++ b/src/cnmf/cnmf.py
@@ -569,7 +569,7 @@ class cNMF():
     def factorize_multi_process(self, total_workers):
         """
         multiproces wrapper for nmf.factorize()
-        factorize_mp_signature is direct wrapper around factorize to be able to launch it form mp.
+        factorize_multi_process() is direct wrapper around factorize to be able to launch it form mp.
         total_workers: int; number of workers to use.
         """
         list_args = [(x, total_workers, self) for x in range(total_workers)]

--- a/src/cnmf/cnmf.py
+++ b/src/cnmf/cnmf.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 
 import scanpy as sc
 
-from multiprocessing import Pool, Process 
+from multiprocessing import Pool 
 
 
 def save_df_to_npz(obj, filename):

--- a/src/cnmf/cnmf.py
+++ b/src/cnmf/cnmf.py
@@ -567,7 +567,7 @@ class cNMF():
         return(spectra, usages)
 
     def factorize_multi_process(self, total_workers):
-    	"""
+        """
         multiproces wrapper for nmf.factorize()
         factorize_mp_signature is direct wrapper around factorize to be able to launch it form mp.
         total_workers: int; number of workers to use.

--- a/src/cnmf/cnmf.py
+++ b/src/cnmf/cnmf.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 
 import scanpy as sc
 
-from multiprocessing import Pool 
+from multiprocessing import Pool, Process 
 
 
 def save_df_to_npz(obj, filename):
@@ -573,8 +573,11 @@ class cNMF():
         total_workers: int; number of workers to use.
         """
         list_args = [(x, total_workers, self) for x in range(total_workers)]
+        
         with Pool(total_workers) as p:
+            
             p.map(factorize_mp_signature, list_args)
+            p.close()
             p.join()    
     
     def factorize(self,


### PR DESCRIPTION
Hi,

This PR adds the functionality of using python native multiprocess module to parallelize execution of factorize.
To do so it adds 1 function, 1 method (NMF class) and 1 additional import

The method "factorize_multi_process" takes the maximum number of workers as an integer and launch the corresponding number of  "factorize" call, with the corresponding arguments through the function/wrapper "factorize_mp_signature".

The import is from python std lib: "from multiprocessing import Pool "

usage:
```
# instead of calling 
nmf_obj.factorize()
# call
nmf_obj. factorize_multi_process(<number of workers>)
```


I tested it on a "CentOS Linux release 7.9.2009 (Core)" Linux server.

This could be used directly inside a python program or replace the CLI launch 1 by 1. 
In a first time, I did not want to change your code, neither the README. 

If you wish, I can make a PR that adds the option to use multiprocess from the CLI (keeping the older option available).
And  detail those options (CLI and in script) in the README.

Best,
Romain


