### PR TITLE
Skip clustering if k > n_topics

### DIFF
--- a/src/cnmf/cnmf.py
+++ b/src/cnmf/cnmf.py
@@ -790,8 +790,8 @@ class cNMF():
             # Compute the silhouette score
             stability = silhouette_score(l2_spectra.values, kmeans_cluster_labels, metric='euclidean')
 
-            # Find median usage for each gene across cluster
-            median_spectra = l2_spectra.groupby(kmeans_cluster_labels).median()
+        # Find median usage for each gene across cluster
+        median_spectra = l2_spectra.groupby(kmeans_cluster_labels).median()
 
         # Normalize median spectra to probability distributions.
         median_spectra = (median_spectra.T/median_spectra.sum(1)).T

--- a/src/cnmf/cnmf.py
+++ b/src/cnmf/cnmf.py
@@ -800,7 +800,8 @@ class cNMF():
         rf_pred_norm_counts = rf_usages.dot(median_spectra)
         
         # Re-order usage by total contribution
-        norm_usages = rf_usages.div(rf_usages.sum(axis=1), axis=0)      
+        rf_usages_sum = rf_usages.sum(axis=1)
+        norm_usages = rf_usages.div(np.where(rf_usages_sum != 0, rf_usages_sum, 1), axis=0)
         reorder = norm_usages.sum(axis=0).sort_values(ascending=False)
         rf_usages = rf_usages.loc[:, reorder.index]
         norm_usages = norm_usages.loc[:, reorder.index]
@@ -828,7 +829,8 @@ class cNMF():
         tpm_stats = load_df_from_npz(self.paths['tpm_stats'])
         spectra_tpm = self.refit_spectra(tpm.X, norm_usages.astype(tpm.X.dtype))
         spectra_tpm = pd.DataFrame(spectra_tpm, index=rf_usages.columns, columns=tpm.var.index)
-        spectra_tpm = spectra_tpm.div(spectra_tpm.sum(axis=1), axis=0) * 1e6
+        spectra_tpm_sum = spectra_tpm.sum(axis=1)
+        spectra_tpm = spectra_tpm.div(np.where(spectra_tpm_sum != 0, spectra_tpm_sum, 1), axis=0) * 1e6
         
         # Convert spectra to Z-score units, and obtain results for all genes by running last step of NMF
         # with usages fixed and Z-scored TPM as the input matrix


### PR DESCRIPTION
I get a `ValueError` if the number of topics after density filtering is less than the number of desired components.

```
Traceback (most recent call last):
  File "/Users/scottgigante/envs/immunaISR/lib/python3.8/site-packages/cnmf/cnmf.py", line 727, in consensus
    kmeans_model.fit(l2_spectra)
  File "/Users/scottgigante/envs/immunaISR/lib/python3.8/site-packages/sklearn/cluster/_kmeans.py", line 1426, in fit
    self._check_params_vs_input(X)
  File "/Users/scottgigante/envs/immunaISR/lib/python3.8/site-packages/sklearn/cluster/_kmeans.py", line 1362, in _check_params_vs_input
    super()._check_params_vs_input(X, default_n_init=10)
  File "/Users/scottgigante/envs/immunaISR/lib/python3.8/site-packages/sklearn/cluster/_kmeans.py", line 859, in _check_params_vs_input
    raise ValueError(
ValueError: n_samples=19 should be >= n_clusters=41.
```

This PR solves that issue.