### PR TITLE
Adding the option of regressing out variables when preprocessing count matrix with harmony

### DIFF
--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -230,7 +230,7 @@ class Preprocess():
         adata_RNA.layers['log1p_norm'] = adata_RNA.X
         
         if regression_vars is not None: # Added this code: aregano
-            sc.pp.regress_out(adata_RNA, regression_vars)
+            sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=True)
             adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X
             
         adata_RNA, hvgs = self.normalize_batchcorrect(adata_RNA, harmony_vars=harmony_vars,

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 from collections.abc import Collection
 from sklearn.feature_selection import mutual_info_classif
 import pandas as pd
-from scipy.sparse import hstack, issparse
+from scipy.sparse import hstack, issparse, csr_matrix
 
 def moe_correct_ridge(Z_orig, Z_cos, Z_corr, R, W, K, Phi_Rk, Phi_moe, lamb):
     Z_corr = Z_orig.copy()
@@ -232,7 +232,10 @@ class Preprocess():
         if regression_vars is not None: # Added this code: aregano
             sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=add_intercept)
             adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
-            adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X
+            # adata_RNA.X = np.log1p(adata_RNA.X) # log1p after regression to allow hvg seurat v3 format to work
+            adata_RNA.X = csr_matrix(adata_RNA.X)
+            adata_RNA.layers['norm_regressed'] = adata_RNA.X
+            
             
             
         adata_RNA, hvgs = self.normalize_batchcorrect(adata_RNA, harmony_vars=harmony_vars,
@@ -305,7 +308,10 @@ class Preprocess():
         """  
                 
         if n_top_genes is not None:
-            sc.pp.highly_variable_genes(_adata, flavor='seurat_v3', n_top_genes=n_top_genes)
+            sc.pp.highly_variable_genes(_adata, 
+                                        # flavor='seurat_v3', # throws errors due to regressed out matrix giving out a dense matrix as output
+                                        flavor = 'seurat',
+                                        n_top_genes=n_top_genes)
         elif 'highly_variable' not in _adata.var.columns:
             raise Exception("If a numeric value for n_top_genes is not provided, you must include a highly_variable column in _adata")                            
             

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -227,7 +227,6 @@ class Preprocess():
 
         tp10k = adata_RNA.copy()
         sc.pp.normalize_total(tp10k, target_sum=librarysize_targetsum, copy=False)
-        adata_RNA.layers['log1p_norm'] = adata_RNA.X
         
         if regression_vars is not None: # Added this code: aregano
             sc.pp.normalize_total(adata_RNA, target_sum=librarysize_targetsum, copy=False)
@@ -236,9 +235,9 @@ class Preprocess():
             # adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
             adata_RNA.X = csr_matrix(adata_RNA.X) 
             
-            adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X
+            adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X.copy()
             adata_RNA.X = np.expm1(adata_RNA.X)
-            adata_RNA.layers['norm_regressed'] = adata_RNA.X
+            adata_RNA.layers['norm_regressed'] = adata_RNA.X.copy()
             
             
             

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -230,11 +230,15 @@ class Preprocess():
         adata_RNA.layers['log1p_norm'] = adata_RNA.X
         
         if regression_vars is not None: # Added this code: aregano
+            sc.pp.normalize_total(adata_RNA, target_sum=librarysize_targetsum, copy=False)
             sc.pp.log1p(adata_RNA)
             sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=add_intercept)
-            adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
-            adata_RNA.X = csr_matrix(adata_RNA.X)
+            # adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
+            adata_RNA.X = csr_matrix(adata_RNA.X) 
+            
             adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X
+            adata_RNA.X = np.expm1(adata_RNA.X)
+            adata_RNA.layers['norm_regressed'] = adata_RNA.X
             
             
             

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -231,7 +231,10 @@ class Preprocess():
         if regression_vars is not None: # Added this code: aregano
             sc.pp.normalize_total(adata_RNA, target_sum=librarysize_targetsum, copy=False)
             sc.pp.log1p(adata_RNA)
-            sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=add_intercept)
+            if add_intercept:
+                sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=add_intercept) # modified regress_out function in scanpy to allow adding the intercept
+            else:
+                sc.pp.regress_out(adata_RNA, regression_vars)
             # adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
             adata_RNA.X = csr_matrix(adata_RNA.X) 
             

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -230,11 +230,11 @@ class Preprocess():
         adata_RNA.layers['log1p_norm'] = adata_RNA.X
         
         if regression_vars is not None: # Added this code: aregano
+            sc.pp.log1p(adata_RNA)
             sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=add_intercept)
             adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
-            # adata_RNA.X = np.log1p(adata_RNA.X) # log1p after regression to allow hvg seurat v3 format to work
             adata_RNA.X = csr_matrix(adata_RNA.X)
-            adata_RNA.layers['norm_regressed'] = adata_RNA.X
+            adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X
             
             
             
@@ -309,8 +309,8 @@ class Preprocess():
                 
         if n_top_genes is not None:
             sc.pp.highly_variable_genes(_adata, 
-                                        # flavor='seurat_v3', # throws errors due to regressed out matrix giving out a dense matrix as output
-                                        flavor = 'seurat',
+                                        flavor='seurat_v3', # throws errors due to regressed out matrix giving out a dense matrix as output
+                                        # flavor = 'seurat',
                                         n_top_genes=n_top_genes)
         elif 'highly_variable' not in _adata.var.columns:
             raise Exception("If a numeric value for n_top_genes is not provided, you must include a highly_variable column in _adata")                            

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -135,6 +135,7 @@ class Preprocess():
     def preprocess_for_cnmf(self, _adata, feature_type_col = None, adt_feature_name = 'Antibody Capture',
                             harmony_vars= None, n_top_rna_genes = 2000, librarysize_targetsum= 1e4,
                             max_scaled_thresh = None, quantile_thresh = .9999, makeplots=True, theta=1,
+                            regression_vars = None,
                             save_output_base=None, max_iter_harmony=20):
         """
         Runs minimal preprocessing for cNMF, specifically preparing an HVG filtered, normalized, optionally batch corrected, output file
@@ -175,6 +176,9 @@ class Preprocess():
         makeplots : boolean (default=True)
         
         theta : float (default=1)
+        
+        regression_vars : list of strings (default=None)
+            If provided, regress out these variables from the RNA data prior to further normalization, the strings should indicate columns from adata.obs showing pct of expression in each cell 
         
         max_iter_harmony : int (default=20)
             Maximum number of Harmony iterations to use
@@ -223,6 +227,11 @@ class Preprocess():
 
         tp10k = adata_RNA.copy()
         sc.pp.normalize_total(tp10k, target_sum=librarysize_targetsum, copy=False)
+        
+        if regression_vars is not None: # Added this code: aregano
+            sc.pp.regress_out(adata_RNA, regression_vars)
+            adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X
+            
         adata_RNA, hvgs = self.normalize_batchcorrect(adata_RNA, harmony_vars=harmony_vars,
                                                 n_top_genes = n_top_rna_genes, 
                                                 librarysize_targetsum= librarysize_targetsum,

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -227,6 +227,7 @@ class Preprocess():
 
         tp10k = adata_RNA.copy()
         sc.pp.normalize_total(tp10k, target_sum=librarysize_targetsum, copy=False)
+        adata_RNA.layers['log1p_norm'] = adata_RNA.X
         
         if regression_vars is not None: # Added this code: aregano
             sc.pp.regress_out(adata_RNA, regression_vars)

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -236,11 +236,14 @@ class Preprocess():
             else:
                 sc.pp.regress_out(adata_RNA, regression_vars)
             # adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
-            adata_RNA.X = csr_matrix(adata_RNA.X) 
-            
-            adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X.copy()
+            adata_RNA.layers['log1p_norm_regressed'] = csr_matrix(adata_RNA.X.copy())
             adata_RNA.X = np.expm1(adata_RNA.X)
-            adata_RNA.layers['norm_regressed'] = adata_RNA.X.copy()
+            adata_RNA.layers['norm_regressed'] = csr_matrix(adata_RNA.X.copy())
+            
+            # Calculate original library sizes from the saved raw counts
+            original_lib_sizes = np.asarray(adata_RNA.layers['norm'].sum(axis=1)).squeeze()
+            scaling_factors = original_lib_sizes / librarysize_targetsum
+            adata_RNA.X = diags(scaling_factors) @ adata_RNA.layers['norm_regressed']
             
             
             

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -135,7 +135,7 @@ class Preprocess():
     def preprocess_for_cnmf(self, _adata, feature_type_col = None, adt_feature_name = 'Antibody Capture',
                             harmony_vars= None, n_top_rna_genes = 2000, librarysize_targetsum= 1e4,
                             max_scaled_thresh = None, quantile_thresh = .9999, makeplots=True, theta=1,
-                            regression_vars = None,
+                            regression_vars = None, add_intercept=False,
                             save_output_base=None, max_iter_harmony=20):
         """
         Runs minimal preprocessing for cNMF, specifically preparing an HVG filtered, normalized, optionally batch corrected, output file
@@ -230,8 +230,10 @@ class Preprocess():
         adata_RNA.layers['log1p_norm'] = adata_RNA.X
         
         if regression_vars is not None: # Added this code: aregano
-            sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=True)
+            sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=add_intercept)
+            adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
             adata_RNA.layers['log1p_norm_regressed'] = adata_RNA.X
+            
             
         adata_RNA, hvgs = self.normalize_batchcorrect(adata_RNA, harmony_vars=harmony_vars,
                                                 n_top_genes = n_top_rna_genes, 

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -234,13 +234,15 @@ class Preprocess():
             sc.pp.log1p(adata_RNA)
             if add_intercept:
                 sc.pp.regress_out(adata_RNA, regression_vars, add_intercept=add_intercept) # modified regress_out function in scanpy to allow adding the intercept
+                print('regressed out matrix produced with intercept')
             else:
                 sc.pp.regress_out(adata_RNA, regression_vars)
-            # adata_RNA.X = adata_RNA.X - adata_RNA.X.min() # to avoid negative values after regression
+                print('regressed out matrix produced without intercept')
             adata_RNA.layers['log1p_norm_regressed'] = csr_matrix(adata_RNA.X.copy())
             adata_RNA.X = np.expm1(adata_RNA.X)
             adata_RNA.layers['norm_regressed'] = csr_matrix(adata_RNA.X.copy())
-            
+            adata_RNA.X = adata_RNA.layers['log1p_norm_regressed'].copy()
+            print('starting normalization and batch correction')
             
         adata_RNA, hvgs = self.normalize_batchcorrect(adata_RNA, harmony_vars=harmony_vars,
                                                 n_top_genes = n_top_rna_genes, 

--- a/src/cnmf/preprocess.py
+++ b/src/cnmf/preprocess.py
@@ -312,7 +312,7 @@ class Preprocess():
         """  
                 
        if n_top_genes is not None:
-            if _adata.layers['log1p_norm_regressed'] is not None:
+            if 'log1p_norm_regressed' in _adata.layers and _adata.layers['log1p_norm_regressed'] is not None: # modified this code: aregano
                 _adata.X = _adata.layers['log1p_norm_regressed'].copy()
                 sc.pp.highly_variable_genes(_adata, 
                         flavor = 'seurat', # allows for hvg using log1p normalized reads, which is required if you want to regress out variables
@@ -327,7 +327,7 @@ class Preprocess():
             raise Exception("If a numeric value for n_top_genes is not provided, you must include a highly_variable column in _adata")                            
             
         if harmony_vars is not None:
-            if _adata.layers['norm_regressed'] is not None:
+            if 'norm_regressed' in _adata.layers and _adata.layers['norm_regressed'] is not None:
                 _adata.X = _adata.layers['norm_regressed'].copy()
                 anorm = _adata[:, _adata.var['highly_variable']]
                 print('Using normalized regressed data for batch correction')


### PR DESCRIPTION
Greetings,

First thanks a mil for developing such a straightforward package for cNMF computing! I am very satisfied with how it is processing some pediatric brain cancer datasets I am working on, specifically since you added the preprocess_for_cnnmf() function, where harmonization is performed on the counts matrix of the various samples prior to cNMF computation. 

In said function I saw that the option of regressing out specific genes was not included, which is an option that is standard on harmony pipelines. I believe you did not include it due to the need of needing the counts matrix to go through log1p normalization prior to applying the regressing out linear model provided in scanpy.

I have modified the code for preprocess_for_cnmf() by adding the regressing_vars argument. In brief I regress out the log1p counts matrix and then I revert it back to the normalize_total() normalization step so the pipeline can be carried out normally. I believe with that should suffice to make it effective and it adds an extra tool that can improve the analysis (as it definitely did with mine).

Best,
Alvaro 